### PR TITLE
Bug: Ajuste de header null

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
 
 
   "rules": {
-    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "indent": ["error", 4, { "SwitchCase": 2 }],
     "no-new-func": "off",
     "semi": ["error", "never"],
     "accessor-pairs": "error",

--- a/README.md
+++ b/README.md
@@ -1,37 +1,39 @@
-HttpClient
+# HttpClient 1.4.1
+
 [![Build Status](https://travis-ci.org/thrust-bitcodes/http-client.svg?branch=master)](https://travis-ci.org/thrust-bitcodes/http-client) [![GitHub release](https://img.shields.io/github/release/thrust-bitcodes/http-client.svg)](https://github.com/thrust-bitcodes/http-client/releases)
-===============
 
 HttpClient é um *bitcode* de acesso HTTP e HTTPS para [ThrustJS](https://github.com/thrustjs/thrust).
 
-# Instalação
+## Instalação
 
-Posicionado em um app [ThrustJS](https://github.com/thrustjs/thrust), no seu terminal:
+Dentro do diretório de um projeto [ThrustJS](https://github.com/thrustjs/thrust), digite em seu terminal:
 
 ```bash
-thrust install http-client
+tpm install http-client
 ```
 
 ## Tutorial
 
 ```javascript
-let httpClient = require('http-client')
+const httpClient = require('http-client')
 
-let result = httpClient
+const result = httpClient
   // .post('http://localhost:8778/test/pecho', {nome: 'P Paulo', idade: 13})
   .post('http://localhost:8778/test/pecho')
   .headers({
     'Authorization': 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
     'Proxy-Authenticate': 'Basic realm="Access to the internal site"'
   })
-  .disableCertificateValidation() //Usado quando o endpoint é acessado via https certificado e não temos o certificado para validação
+  //Use o caso abaixo quando o endpoint é acessado via https certificado e não temos o certificado para validação
+  .disableCertificateValidation()
   .params({nome: 'David', idade: 10})
+  // Este já é o padrão!
   .charset('UTF-8')
   .contentType('application/json')
   .property('prop', 'value')
   .fetch()
 
-console.log(result)
+console.log(JSON.stringify(result))
 ```
 
 O *bitcode* http-client contém os seguintes métodos, sendo que cada um deles retornam o mesmo *builder* conforme exemplo acima.
@@ -45,36 +47,68 @@ delete(url, params)
 
 ## What's new
 
-v1.3.3 - Fix: Ajustando leitura do retorno e tratando requisições sem retorno.
+v1.4.1
 
-v1.3.2 - Fix: Quando uma requisição retorna com erro, o atributo "body" no objeto de retorno fica com o valor _undefined_.
+- Fix: Correção de *bug* de leitura do Header: Há casos em que *header* retorna o valor `null` e ao montar o objeto de
+resposta o JS não aceita este valor como atributo do objeto `header`.
+- O objeto `HttpClient` informa a versão através do atributo `version` .
 
-v1.3.1 - Fix: Método GET chamado com query-string na URL estava com erro
-* Método GET quando iniciado com query-string e sem parâmetros estava com erro
+v1.4.0
 
-v1.3.0 - Fix: os _headers_ configurados pelos métodos [headers] e [property] não estão sendo aplicados para o método GET
-* Correção para que os _headers_ sejam aplicados para o método GET
-* Definição do _user-agent_ a ser utilizado pelo thrust no cabeçalho HTTP<br>
-'user-agent': 'thrustBot-http-client/1.3.0'
-* **OBSERVAÇÃO:** neste release o retonro do [fetch] está sendo alterado<br>
-De: { code: httpCode, body: body, **header**: header }<br>
-Para: { code: httpCode, body: body, **headers**: header }
+- ?
 
-v1.2.0 - Implementação do método 'headers'
-* Melhoria: adicionado o método 'headers' utilizado para configurar os atributos do HTTP Header através de um único objeto JSON
-* Aumento dos cenários de teste do bitcode
+v1.3.3
 
-v1.1.0 - Correções e melhorias do GET e inserção da Suite Teste Case para o bitcode
-* Correção do objeto 'header' que estava com todos os valores em formato array de string e deveriam estar em string.
-* Correção para o método GET quando o mesmo não recebe parâmetros.
-* Correção dos testes de validação do 'Content-Type' de === para indexOf, haja visto que o charset pode ser definido nesta propriedade, o que é bastante comum.
-* Adicionado Test Suite Case para o bitcode.
+- Fix: Ajustando leitura do retorno e tratando requisições sem retorno.
 
-v1.0.0 - Adição de parametro com os headers no retorno da requisição
-* Acrescentado o atributo 'headers' ao objeto de retorno do 'fetch'.<br>
-De: { code: httpCode, body: body }<br>
-Para: { code: httpCode, body: body, header : header }
+v1.3.2
 
-v0.2.0 - Alterações para retornar o código e mensagem de erro de maneira mais específica
-* Adicionado métodos de tratamento de erros (ex: 'get_error_content').
-* Melhorado / corrigido a serialização dos parâmetros das requisições.
+- Fix: Quando uma requisição retorna com erro, o atributo "body" no objeto de retorno fica com o valor _undefined_.
+
+v1.3.1
+
+- Fix: Método GET chamado com query-string na URL estava com erro
+- Método GET quando iniciado com query-string e sem parâmetros estava com erro.
+
+v1.3.0
+
+- Fix: os _headers_ configurados pelos métodos [headers] e [property] não estão sendo aplicados para o método GET
+- Correção para que os _headers_ sejam aplicados para o método GET
+- Definição do _user-agent_ a ser utilizado pelo thrust no cabeçalho HTTP
+
+  'user-agent': 'thrustBot-http-client/1.3.0'
+
+**OBSERVAÇÃO:** neste release o retonro do [fetch] está sendo alterado
+
+  De: { code: httpCode, body: body, **header**: header }
+
+  Para: { code: httpCode, body: body, **headers**: header }
+
+v1.2.0
+
+- Implementação do método 'headers'
+- Melhoria: adicionado o método 'headers' utilizado para configurar os atributos do HTTP Header através de um único objeto JSON
+- Aumento dos cenários de teste do bitcode
+
+v1.1.0
+
+- Correções e melhorias do GET e inserção da Suite Teste Case para o bitcode
+- Correção do objeto 'header' que estava com todos os valores em formato array de string e deveriam estar em string.
+- Correção para o método GET quando o mesmo não recebe parâmetros.
+- Correção dos testes de validação do 'Content-Type' de === para indexOf, haja visto que o charset pode ser definido nesta propriedade, o que é bastante comum.
+- Adicionado Test Suite Case para o bitcode.
+
+v1.0.0
+
+- Adição de parametro com os headers no retorno da requisição
+- Acrescentado o atributo 'headers' ao objeto de retorno do 'fetch'.
+
+  De: { code: httpCode, body: body }
+
+  Para: { code: httpCode, body: body, header : header }
+
+v0.2.0
+
+- Alterações para retornar o código e mensagem de erro de maneira mais específica
+- Adicionado métodos de tratamento de erros (ex: 'get_error_content').
+- Melhorado / corrigido a serialização dos parâmetros das requisições.

--- a/brief.json
+++ b/brief.json
@@ -1,13 +1,14 @@
 {
-  "description": "HTTP client module",
+  "description": "HTTP client bitcode",
   "name": "http-client",
   "path": "index.js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Nery Jr",
   "contributors": [
     "Cleverson Puche",
     "Bruno Machado",
-    "Leonardo Delfinio"
+    "Leonardo Delfino",
+    "Ozair Jr"
   ],
   "dependencies": []
 }

--- a/index.js
+++ b/index.js
@@ -8,211 +8,210 @@ var X509TrustManager = Java.type('javax.net.ssl.X509TrustManager')
 var SecureRandom = Java.type('java.security.SecureRandom')
 
 function getBytes(str, charset) {
-  str = str || ''
-  charset = charset || 'utf-8'
-  if (!str.getBytes) {
-    let StringHelper = Java.type('br.com.softbox.thrust.api.ThrustStringHelper')
-    return StringHelper.getBytes(str, charset)
-  }
-  return str.getBytes(charset)
+    str = str || ''
+    charset = charset || 'utf-8'
+    if (!str.getBytes) {
+        let StringHelper = Java.type('br.com.softbox.thrust.api.ThrustStringHelper')
+        return StringHelper.getBytes(str, charset)
+    }
+    return str.getBytes(charset)
 }
 
 function mountHttpRequest(method, url, reqParams) {
-  var params = reqParams
-  var properties = {
-    'charset': 'utf-8',
-    'Content-Type': 'application/x-www-form-urlencoded'
-  }
-
-  var fluent = {
-    params: function(pars) {
-      if ((isObject(params) || params === undefined) && isObject(pars)) {
-        params = merge((params || {}), pars)
-      } else {
-        params = pars
-      }
-      return fluent
-    },
-
-    property: function(property, value) {
-      properties[property] = value
-
-      return fluent
-    },
-
-    headers: function(headers) {
-      properties = Object.assign({}, properties, headers)
-
-      return fluent
-    },
-
-    charset: function(value) {
-      properties['Accept-Charset'] = value
-
-      return fluent
-    },
-
-    contentType: function(value) {
-      properties['Content-Type'] = value
-
-      return fluent
-    },
-
-    getContent: function(httpConnection) {
-      var inputStream
-      var scanner
-
-      try {
-        inputStream = httpConnection.getErrorStream()
-
-        if (!inputStream) {
-          inputStream = httpConnection.getInputStream()
-        }
-
-        scanner = new Scanner(inputStream, 'utf-8').useDelimiter('\\Z|\\A')
-
-        if (scanner.hasNext()) {
-          return scanner.next()
-        }
-      } finally {
-        scanner && scanner.close()
-        inputStream && inputStream.close()
-      }
-    },
-
-    disableCertificateValidation: function() {
-      var trustAllCerts = new X509TrustManager({
-        getAcceptedIssuers: function() {
-          return null
-        },
-        checkClientTrusted: function(certs, authType) {
-        },
-        checkServerTrusted: function(certs, authType) {
-        }
-      })
-
-      HttpsURLConnection.setDefaultHostnameVerifier(function(hostname, sslSession) {
-        return true
-      })
-
-      var sc = SSLContext.getInstance('SSL')
-      sc.init(null, [trustAllCerts], new SecureRandom())
-      HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory())
-
-      return fluent
-    },
-
-    fetch: function _fetch() {
-      var httpConnection
-
-      if (method.toUpperCase() === 'POST' || method.toUpperCase() === 'PUT') {
-        var output
-
-        httpConnection = new URL(url).openConnection()
-
-        httpConnection.setDoOutput(true)
-        httpConnection.setRequestMethod(method)
-
-        for (var prop in properties) {
-          httpConnection.setRequestProperty(prop, properties[prop])
-        }
-
-        if (params && params.constructor && params.constructor.name === 'Object') {
-          if (properties['Content-Type'].indexOf('application/json') >= 0) {
-            params = JSON.stringify(params)
-          } else if (properties['Content-Type'] === 'application/x-www-form-urlencoded') {
-            params = serializeParams(params)
-          } else {
-            params = JSON.stringify(params)
-          }
-        }
-
-        output = httpConnection.getOutputStream()
-
-        let isBinary = properties['Content-Type'].indexOf('application/zip') > -1 || properties['Content-Type'].indexOf('application/octet-stream') > -1
-
-        if (!params || typeof params === 'string') {
-          var str = params || ''
-          var outBuffer = getBytes(params, properties.charset)
-          output.write(outBuffer)
-        } else if (isBinary) {
-          copyStreams(params, output)
-        }
-      } else {
-        if (params && params.constructor && params.constructor.name === 'Object') {
-          url += '?' + serializeParams(params)
-        } else if (params !== undefined) {
-          url += '?' + params
-        }
-        httpConnection = new URL(url).openConnection()
-
-        for (var prp in properties) {
-          httpConnection.setRequestProperty(prp, properties[prp])
-        }
-      }
-
-      var httpCode = 500
-      var header = {}
-      var body = {}
-      var exc
-
-      try {
-        httpCode = httpConnection.getResponseCode()
-        httpConnection.getHeaderFields().forEach(function(key, list) {
-          if (list) {
-            if (key === null) {
-              key = 'null'
-            }
-            header[key] = list.size() === 1 ? list.get(0) : list.toArray()
-          }
-        })
-        var data = fluent.getContent(httpConnection)
-        var isJSON = data && (header['Content-Type'] && header['Content-Type'].indexOf('application/json') >= 0)
-        body = isJSON ? JSON.parse(data) : data
-      } catch (e) {
-        exc = e
-      }
-      return { code: httpCode, body: body, headers: header, exc: exc }
+    var params = reqParams
+    var properties = {
+        'charset': 'utf-8',
+        'Content-Type': 'application/x-www-form-urlencoded'
     }
-  }
-  return fluent
+
+    var fluent = {
+        params: function(pars) {
+            if ((isObject(params) || params === undefined) && isObject(pars)) {
+                params = merge((params || {}), pars)
+            } else {
+                params = pars
+            }
+            return fluent
+        },
+
+        property: function(property, value) {
+            properties[property] = value
+
+            return fluent
+        },
+
+        headers: function(headers) {
+            properties = Object.assign({}, properties, headers)
+
+            return fluent
+        },
+
+        charset: function(value) {
+            properties['Accept-Charset'] = value
+
+            return fluent
+        },
+
+        contentType: function(value) {
+            properties['Content-Type'] = value
+
+            return fluent
+        },
+
+        getContent: function(httpConnection) {
+            var inputStream
+            var scanner
+
+            try {
+                inputStream = httpConnection.getErrorStream()
+
+                if (!inputStream) {
+                    inputStream = httpConnection.getInputStream()
+                }
+
+                scanner = new Scanner(inputStream, 'utf-8').useDelimiter('\\Z|\\A')
+
+                if (scanner.hasNext()) {
+                    return scanner.next()
+                }
+            } finally {
+                scanner && scanner.close()
+                inputStream && inputStream.close()
+            }
+        },
+
+        disableCertificateValidation: function() {
+            var trustAllCerts = new X509TrustManager({
+                getAcceptedIssuers: function() {
+                    return null
+                },
+                checkClientTrusted: function(certs, authType) {
+                },
+                checkServerTrusted: function(certs, authType) {
+                }
+            })
+
+            HttpsURLConnection.setDefaultHostnameVerifier(function(hostname, sslSession) {
+                return true
+            })
+
+            var sc = SSLContext.getInstance('SSL')
+            sc.init(null, [trustAllCerts], new SecureRandom())
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory())
+
+            return fluent
+        },
+
+        fetch: function _fetch() {
+            var httpConnection
+
+            if (method.toUpperCase() === 'POST' || method.toUpperCase() === 'PUT') {
+                var output
+
+                httpConnection = new URL(url).openConnection()
+
+                httpConnection.setDoOutput(true)
+                httpConnection.setRequestMethod(method)
+
+                for (var prop in properties) {
+                    httpConnection.setRequestProperty(prop, properties[prop])
+                }
+
+                if (params && params.constructor && params.constructor.name === 'Object') {
+                    if (properties['Content-Type'].indexOf('application/json') >= 0) {
+                        params = JSON.stringify(params)
+                    } else if (properties['Content-Type'] === 'application/x-www-form-urlencoded') {
+                        params = serializeParams(params)
+                    } else {
+                        params = JSON.stringify(params)
+                    }
+                }
+
+                output = httpConnection.getOutputStream()
+
+                let isBinary = properties['Content-Type'].indexOf('application/zip') > -1 || properties['Content-Type'].indexOf('application/octet-stream') > -1
+
+                if (!params || typeof params === 'string') {
+                    var outBuffer = getBytes(params, properties.charset)
+                    output.write(outBuffer)
+                } else if (isBinary) {
+                    copyStreams(params, output)
+                }
+            } else {
+                if (params && params.constructor && params.constructor.name === 'Object') {
+                    url += '?' + serializeParams(params)
+                } else if (params !== undefined) {
+                    url += '?' + params
+                }
+                httpConnection = new URL(url).openConnection()
+
+                for (var prp in properties) {
+                    httpConnection.setRequestProperty(prp, properties[prp])
+                }
+            }
+
+            var httpCode = 500
+            var header = {}
+            var body = {}
+            var exc
+
+            try {
+                httpCode = httpConnection.getResponseCode()
+                httpConnection.getHeaderFields().forEach(function(key, list) {
+                    if (list) {
+                        if (key === null) {
+                            key = 'null'
+                        }
+                        header[key] = list.size() === 1 ? list.get(0) : list.toArray()
+                    }
+                })
+                var data = fluent.getContent(httpConnection)
+                var isJSON = data && (header['Content-Type'] && header['Content-Type'].indexOf('application/json') >= 0)
+                body = isJSON ? JSON.parse(data) : data
+            } catch (e) {
+                exc = e
+            }
+            return { code: httpCode, body: body, headers: header, exc: exc }
+        }
+    }
+    return fluent
 }
 
 function copyStreams(inStream, outStream) {
-  let len
-  let buffer = new Byte(1024)
-  while ((len = inStream.read(buffer)) !== -1) {
-    outStream.write(buffer, 0, len)
-  }
+    let len
+    let buffer = new Byte(1024)
+    while ((len = inStream.read(buffer)) !== -1) {
+        outStream.write(buffer, 0, len)
+    }
 }
 
 function serializeParams(obj, prefix) {
-  var str = []
-  var p
+    var str = []
+    var p
 
-  for (p in obj) {
-    if (obj.hasOwnProperty(p)) {
-      var k = prefix ? prefix + '[' + p + ']' : p
-      var v = obj[p]
+    for (p in obj) {
+        if (obj.hasOwnProperty(p)) {
+            var k = prefix ? prefix + '[' + p + ']' : p
+            var v = obj[p]
 
-      str.push((v !== null && typeof v === 'object')
-        ? serializeParams(v, k)
-        : encodeURIComponent(k) + '=' + encodeURIComponent(v))
+            str.push((v !== null && typeof v === 'object')
+                ? serializeParams(v, k)
+                : encodeURIComponent(k) + '=' + encodeURIComponent(v))
+        }
     }
-  }
 
-  return str.join('&')
+    return str.join('&')
 }
 
 function merge(obj1, obj2) {
-  var obj3 = {}
-  for (var attrname in obj1) { obj3[attrname] = obj1[attrname] }
-  for (var objAttrName in obj2) { obj3[objAttrName] = obj2[objAttrName] }
-  return obj3
+    var obj3 = {}
+    for (var attrname in obj1) { obj3[attrname] = obj1[attrname] }
+    for (var objAttrName in obj2) { obj3[objAttrName] = obj2[objAttrName] }
+    return obj3
 }
 
 function isObject(val) {
-  return val && typeof val === 'object'
+    return val && typeof val === 'object'
 }
 
 /**
@@ -225,10 +224,10 @@ function isObject(val) {
   * HTTPClient.post("http://localhost:8080/test/hello").fetch()
   */
 var HTTPClient = {
-  get: function(url, params) { return mountHttpRequest('GET', url, params) },
-  post: function(url, params) { return mountHttpRequest('POST', url, params) },
-  put: function(url, params) { return mountHttpRequest('PUT', url, params) },
-  delete: function(url, params) { return mountHttpRequest('DELETE', url, params) }
+    get: function(url, params) { return mountHttpRequest('GET', url, params) },
+    post: function(url, params) { return mountHttpRequest('POST', url, params) },
+    put: function(url, params) { return mountHttpRequest('PUT', url, params) },
+    delete: function(url, params) { return mountHttpRequest('DELETE', url, params) }
 }
 HTTPClient.version = '1.4.1'
 exports = HTTPClient

--- a/index.js
+++ b/index.js
@@ -7,6 +7,16 @@ var SSLContext = Java.type('javax.net.ssl.SSLContext')
 var X509TrustManager = Java.type('javax.net.ssl.X509TrustManager')
 var SecureRandom = Java.type('java.security.SecureRandom')
 
+function getBytes(str, charset) {
+  str = str || ''
+  charset = charset || 'utf-8'
+  if (!str.getBytes) {
+    let StringHelper = Java.type('br.com.softbox.thrust.api.ThrustStringHelper')
+    return StringHelper.getBytes(str, charset)
+  }
+  return str.getBytes(charset)
+}
+
 function mountHttpRequest(method, url, reqParams) {
   var params = reqParams
   var properties = {
@@ -122,7 +132,9 @@ function mountHttpRequest(method, url, reqParams) {
         let isBinary = properties['Content-Type'].indexOf('application/zip') > -1 || properties['Content-Type'].indexOf('application/octet-stream') > -1
 
         if (!params || typeof params === 'string') {
-          output.write((params || '').getBytes(properties.charset))
+          var str = params || ''
+          var outBuffer = getBytes(params, properties.charset)
+          output.write(outBuffer)
         } else if (isBinary) {
           copyStreams(params, output)
         }

--- a/test/test.httpClient.js
+++ b/test/test.httpClient.js
@@ -17,198 +17,172 @@ let httpClient = require('./index')
 //   .fetch()
 
 function exec(describe, it, beforeEach, afterEach, expect, should, assert) {
-  var rs
-  // afterEach(function() { })
-  // beforeEach(function() { })
+    var rs
+    // afterEach(function() { })
+    // beforeEach(function() { })
 
-<<<<<<< HEAD
-  describe('Client HTTP e HTTPS para thrust', function() {
-    describe('Método [GET] Firebase Functions', function() {
-      it('Executando método GET retornando um objeto JSON', function() {
-        var token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjMwNDZhMTU2MzczNjZiNGQ2NGQ5YTVhYmIzMzczMTgyYmE0ZDdjZmIifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vZmlyZWZpcnN0LTg3NzgiLCJhdWQiOiJmaXJlZmlyc3QtODc3OCIsImF1dGhfdGltZSI6MTUyNTAwNTEzMSwidXNlcl9pZCI6IjU2eVIwZGRMRW9Ua2FYWmRnTTY0cmVScnBadzEiLCJzdWIiOiI1NnlSMGRkTEVvVGthWFpkZ002NHJlUnJwWncxIiwiaWF0IjoxNTI1MDA5MjIyLCJleHAiOjE1MjUwMTI4MjIsImVtYWlsIjoibmVyeUBzb2Z0Ym94LmNvbS5iciIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiZmlyZWJhc2UiOnsiaWRlbnRpdGllcyI6eyJlbWFpbCI6WyJuZXJ5QHNvZnRib3guY29tLmJyIl19LCJzaWduX2luX3Byb3ZpZGVyIjoicGFzc3dvcmQifX0.t_Q0ZbMTPUxJTjpzIV9fylMuv0s0kRmHd3nUfMQ86z668iY4kf95-S6_5y-JUN2vb71kBaSmBCzakKnP8aYgcLTRw40OZPN_v7zR0GaQF_i3CqYDWIFxd6nYpH_hK5Ma69ukLzk9-8O5JL9stOrZpp_eBwtAu67SZUnrsvVTZ_jse7EGspNkQqZOFQP_A-tgcGVTOlww16PzMKW83DMUGXxANehAZdpfVNcGCG7_eI12bzbP14eCnmnp3ljtYI2iEXg7mhw3anVop4THaaGvwjj3y3z7mCI9CFkrxTjs_PeOcK7B4-0q0_3qpKlH2pmtJG6dqDvSqBCkt381WzTxig'
-        rs = httpClient.get('https://us-central1-firefirst-8778.cloudfunctions.net/crud/777')
-          .headers({
-            'user-agent': 'thrustBot-http-client/1.3.0',
-            'Content-Type': 'application/json; charset=UTF-8',
-            'Authorization': 'Bearer ' + token
-          })
-          .fetch()
+    describe('Client HTTP e HTTPS para thrust', function() {
+        describe('Método [GET] Firebase Functions', function() {
+            it('Executando método GET retornando um objeto JSON', function() {
+                var token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjMwNDZhMTU2MzczNjZiNGQ2NGQ5YTVhYmIzMzczMTgyYmE0ZDdjZmIifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vZmlyZWZpcnN0LTg3NzgiLCJhdWQiOiJmaXJlZmlyc3QtODc3OCIsImF1dGhfdGltZSI6MTUyNTAwNTEzMSwidXNlcl9pZCI6IjU2eVIwZGRMRW9Ua2FYWmRnTTY0cmVScnBadzEiLCJzdWIiOiI1NnlSMGRkTEVvVGthWFpkZ002NHJlUnJwWncxIiwiaWF0IjoxNTI1MDA5MjIyLCJleHAiOjE1MjUwMTI4MjIsImVtYWlsIjoibmVyeUBzb2Z0Ym94LmNvbS5iciIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiZmlyZWJhc2UiOnsiaWRlbnRpdGllcyI6eyJlbWFpbCI6WyJuZXJ5QHNvZnRib3guY29tLmJyIl19LCJzaWduX2luX3Byb3ZpZGVyIjoicGFzc3dvcmQifX0.t_Q0ZbMTPUxJTjpzIV9fylMuv0s0kRmHd3nUfMQ86z668iY4kf95-S6_5y-JUN2vb71kBaSmBCzakKnP8aYgcLTRw40OZPN_v7zR0GaQF_i3CqYDWIFxd6nYpH_hK5Ma69ukLzk9-8O5JL9stOrZpp_eBwtAu67SZUnrsvVTZ_jse7EGspNkQqZOFQP_A-tgcGVTOlww16PzMKW83DMUGXxANehAZdpfVNcGCG7_eI12bzbP14eCnmnp3ljtYI2iEXg7mhw3anVop4THaaGvwjj3y3z7mCI9CFkrxTjs_PeOcK7B4-0q0_3qpKlH2pmtJG6dqDvSqBCkt381WzTxig'
+                rs = httpClient.get('https://us-central1-firefirst-8778.cloudfunctions.net/crud/777')
+                    .headers({
+                        'user-agent': 'thrustBot-http-client/1.3.0',
+                        'Content-Type': 'application/json; charset=UTF-8',
+                        'Authorization': 'Bearer ' + token
+                    })
+                    .fetch()
 
-        expect(rs.code).to.equal(200)
-        expect(rs.body).to.be.an('object')
-        expect(rs.body).to.have.own.property('id')
-        expect(rs.body.id).to.equal('777')
-      })
-    })
-    describe('Método [GET]', function() {
-      it('Executando método GET retornando um array de objetos json', function() {
-=======
-  describe('Client HTTP e HTTPS para thrust', function () {
-    describe('Método [GET]', function () {
-      it('GET com retorno 404', function () {
-        rs = httpClient.get('https://postman-echo.com/status/404')
-          .fetch()
-
-        expect(rs.code).to.equal(404)
-      })
-
-      it('GET com retorno 500', function () {
-        rs = httpClient.get('https://postman-echo.com/status/500')
-          .fetch()
-
-        expect(rs.code).to.equal(500)
-      })
-
-      it('Executando método GET retornando um array de objetos json', function () {
->>>>>>> 87338d182d01395a77642522fabed716ff21fe75
-        rs = httpClient.get('https://jsonplaceholder.typicode.com/posts')
-          .charset('UTF-8')
-          .fetch()
-
-        expect(rs.code).to.equal(200)
-        expect(rs.body).to.be.an('array')
-        expect(rs.body.length).to.equal(101)
-      })
-
-      it('Executando método GET retornando um objeto json', function () {
-        rs = httpClient.get('https://jsonplaceholder.typicode.com/posts/1')
-          .charset('UTF-8')
-          .fetch()
-
-        expect(rs.code).to.equal(200)
-        expect(rs.body.id).to.equal(1)
-      })
-
-      it('Método GET utilizando [.headers]', function () {
-
-        rs = httpClient.get('https://postman-echo.com/headers')
-          .headers({
-            'app': 'thrust',
-            'user-agent': 'thrustBot-http-client/1.3.0',
-            'Content-Type': 'application/json; charset=UTF-8'
-          })
-          .fetch()
-
-        expect(rs.code).to.equal(200)
-        expect(rs.body).to.not.equal(undefined)
-        expect(rs.body.headers).to.not.equal(undefined)
-        expect(rs.body.headers.app).to.equal('thrust')
-      })
-
-      it('GET com disable de certificado', function () {
-        rs = httpClient
-          .get('https://postman-echo.com/status/200')
-          .disableCertificateValidation()
-          .fetch()
-
-        expect(rs.code).to.equal(200)
-      })
-    })
-    describe('Método [POST]', function () {
-
-      it('POST com retorno 404', function () {
-        rs = executaEMostraTempo(function () {
-          return httpClient.post('https://postman-echo.com/status/404')
-            .fetch()
-
-          expect(rs.code).to.equal(404)
-        })
-      })
-
-      it('Executando método POST inserindo um objeto json', function () {
-        rs = executaEMostraTempo(function () {
-          return httpClient.post('https://reqres.in/api/users')
-            .property('user-agent', 'thrustBot-http-client/1.3.0')
-            .contentType('application/json')
-            .params({
-              'name': 'thrust',
-              'job': 'platform'
+                expect(rs.code).to.equal(200)
+                expect(rs.body).to.be.an('object')
+                expect(rs.body).to.have.own.property('id')
+                expect(rs.body.id).to.equal('777')
             })
-            .fetch()
         })
+        describe('Método [GET]', function() {
+            it('Executando método GET retornando um array de objetos json', function() {
+                rs = httpClient.get('https://jsonplaceholder.typicode.com/posts')
+                    .charset('UTF-8')
+                    .fetch()
 
-        expect(rs.code).to.equal(201)
-        expect(rs.body).to.have.own.property('id')
-        expect(rs.body.id).to.not.equal(undefined)
-        expect(rs.body).to.include({ 'name': 'thrust', 'job': 'platform' })
-      })
-
-      it('Executando método POST (site 2) inserindo um objeto json', function () {
-        rs = httpClient.post('https://jsonplaceholder.typicode.com/posts')
-          .property('user-agent', 'thrustBot-http-client/1.3.0')
-          .contentType('application/json; charset=UTF-8')
-          .params({
-            'title': 'foo',
-            'body': 'bar',
-            'userId': 1
-          })
-          .fetch()
-
-        expect(rs.code).to.equal(201)
-        expect(rs.body).to.have.own.property('id')
-        expect(rs.body).to.have.own.property('userId')
-        expect(rs.body.id).to.not.equal(undefined)
-        expect(rs.body).to.include({ 'title': 'foo', 'body': 'bar' })
-      })
-
-      it('Método POST utilizando [.headers]', function () {
-        rs = httpClient.post('https://jsonplaceholder.typicode.com/posts')
-          .headers({
-            'origin': 'chrome-extension://aejoelaoggembcahagimdiliamlcdmfm',
-            // 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36',
-            'user-agent': 'thrustBot-http-client/1.3.0',
-            'Content-Type': 'application/json; charset=UTF-8'
-          })
-          .params({
-            'title': 'foo',
-            'body': 'bar',
-            'userId': 1
-          })
-          .fetch()
-
-        expect(rs.code).to.equal(201)
-        expect(rs.body).to.have.own.property('id')
-        expect(rs.body).to.have.own.property('userId')
-        expect(rs.body.id).to.not.equal(undefined)
-        expect(rs.body).to.include({ 'title': 'foo', 'body': 'bar' })
-      })
-
-      it('Método POST sem body no retorno', function () {
-        rs = executaEMostraTempo(function () {
-          return httpClient.post('https://mockbin.org/echo')
-            .headers({
-              'Accept': 'application/json'
+                expect(rs.code).to.equal(200)
+                expect(rs.body).to.be.an('array')
+                expect(rs.body.length).to.equal(101)
             })
-            .fetch()
-        })
 
-        expect(rs.code).to.equal(200)
-        expect(rs.body).to.equal(undefined)
-      })
+            it('Executando método GET retornando um objeto json', function() {
+                rs = httpClient.get('https://jsonplaceholder.typicode.com/posts/1')
+                    .charset('UTF-8')
+                    .fetch()
+
+                expect(rs.code).to.equal(200)
+                expect(rs.body.id).to.equal(1)
+            })
+
+            it('Método GET utilizando [.headers]', function() {
+                rs = httpClient.get('https://postman-echo.com/headers')
+                    .headers({
+                        'app': 'thrust',
+                        'user-agent': 'thrustBot-http-client/1.3.0',
+                        'Content-Type': 'application/json; charset=UTF-8'
+                    })
+                    .fetch()
+
+                expect(rs.code).to.equal(200)
+                expect(rs.body).to.not.equal(undefined)
+                expect(rs.body.headers).to.not.equal(undefined)
+                expect(rs.body.headers.app).to.equal('thrust')
+            })
+
+            it('GET com disable de certificado', function() {
+                rs = httpClient
+                    .get('https://postman-echo.com/status/200')
+                    .disableCertificateValidation()
+                    .fetch()
+
+                expect(rs.code).to.equal(200)
+            })
+        })
+        describe('Método [POST]', function() {
+            it('POST com retorno 404', function() {
+                rs = executaEMostraTempo(function() {
+                    return httpClient.post('https://postman-echo.com/status/404')
+                        .fetch()
+
+                    expect(rs.code).to.equal(404)
+                })
+            })
+
+            it('Executando método POST inserindo um objeto json', function() {
+                rs = executaEMostraTempo(function() {
+                    return httpClient.post('https://reqres.in/api/users')
+                        .property('user-agent', 'thrustBot-http-client/1.3.0')
+                        .contentType('application/json')
+                        .params({
+                            'name': 'thrust',
+                            'job': 'platform'
+                        })
+                        .fetch()
+                })
+
+                expect(rs.code).to.equal(201)
+                expect(rs.body).to.have.own.property('id')
+                expect(rs.body.id).to.not.equal(undefined)
+                expect(rs.body).to.include({ 'name': 'thrust', 'job': 'platform' })
+            })
+
+            it('Executando método POST (site 2) inserindo um objeto json', function() {
+                rs = httpClient.post('https://jsonplaceholder.typicode.com/posts')
+                    .property('user-agent', 'thrustBot-http-client/1.3.0')
+                    .contentType('application/json; charset=UTF-8')
+                    .params({
+                        'title': 'foo',
+                        'body': 'bar',
+                        'userId': 1
+                    })
+                    .fetch()
+
+                expect(rs.code).to.equal(201)
+                expect(rs.body).to.have.own.property('id')
+                expect(rs.body).to.have.own.property('userId')
+                expect(rs.body.id).to.not.equal(undefined)
+                expect(rs.body).to.include({ 'title': 'foo', 'body': 'bar' })
+            })
+
+            it('Método POST utilizando [.headers]', function() {
+                rs = httpClient.post('https://jsonplaceholder.typicode.com/posts')
+                    .headers({
+                        'origin': 'chrome-extension://aejoelaoggembcahagimdiliamlcdmfm',
+                        // 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36',
+                        'user-agent': 'thrustBot-http-client/1.3.0',
+                        'Content-Type': 'application/json; charset=UTF-8'
+                    })
+                    .params({
+                        'title': 'foo',
+                        'body': 'bar',
+                        'userId': 1
+                    })
+                    .fetch()
+
+                expect(rs.code).to.equal(201)
+                expect(rs.body).to.have.own.property('id')
+                expect(rs.body).to.have.own.property('userId')
+                expect(rs.body.id).to.not.equal(undefined)
+                expect(rs.body).to.include({ 'title': 'foo', 'body': 'bar' })
+            })
+
+            it('Método POST sem body no retorno', function() {
+                rs = executaEMostraTempo(function() {
+                    return httpClient.post('https://mockbin.org/echo')
+                        .headers({
+                            'Accept': 'application/json'
+                        })
+                        .fetch()
+                })
+
+                expect(rs.code).to.equal(200)
+                expect(rs.body).to.equal(undefined)
+            })
+        })
     })
-  })
 }
 
 function executaEMostraTempo(fn) {
-  var di = new Date().getTime()
-  var result = fn()
-  var df = new Date().getTime()
+    var di = new Date().getTime()
+    fn()
+    var df = new Date().getTime()
 
-  print('\tTempo de execução:', (df - di), 'ms.')
+    print('\tTempo de execução:', (df - di), 'ms.')
 
-<<<<<<< HEAD
-res.failure.forEach(function(fail) {
-  print('[' + fail.scenario + '] =>', fail.execption)
-  var i = 0
-  if (fail.execption.printStackTrace && i === 0) {
-    fail.execption.printStackTrace()
-    i++
-  }
-})
-=======
-  return result
+    var res = majesty.run(exec)
+    res.failure.forEach(function(fail) {
+        print('[' + fail.scenario + '] =>', fail.execption)
+        var i = 0
+        if (fail.execption.printStackTrace && i === 0) {
+            fail.execption.printStackTrace()
+            i++
+        }
+    })
+
+    exit(res.failure.length)
 }
->>>>>>> 87338d182d01395a77642522fabed716ff21fe75
-
-var res = majesty.run(exec)
-exit(res.failure.length)


### PR DESCRIPTION
- Se o **nome** do atributo do *header* for `null`, então este será mapeado para `"null"`.
  - Exemplo encontrado: 
```sh
curl -v http://worldclockapi.com/api/json/utc/now
```

- Se o valor de um atributo do *header* for uma lista com mais de um elemento, então iremos obter seus valores como um *array* de objetos.